### PR TITLE
DB Query Fix

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -94,7 +94,7 @@ RegisterServerEvent('rsg-houses:server:sellhouse', function(data)
     local src = source
     local Player = RSGCore.Functions.GetPlayer(src)
 
-    MySQL.update('UPDATE player_houses SET citizenid = NULL, fullname = NULL, owned = 0 WHERE houseid = ?', {data.house})
+    MySQL.update('UPDATE player_houses SET citizenid = 0, fullname = 0, owned = 0 WHERE houseid = ?', {data.house})
 
     MySQL.update('DELETE FROM player_housekeys WHERE houseid = ?', {data.house})
 
@@ -219,7 +219,7 @@ BillingInterval = function()
 
             Wait(1000)
 
-            MySQL.update('UPDATE player_houses SET citizenid = NULL, fullname = NULL, owned = 0 WHERE houseid = ?', {row.houseid})
+            MySQL.update('UPDATE player_houses SET citizenid = 0, fullname = 0, owned = 0 WHERE houseid = ?', {row.houseid})
 
             MySQL.update('DELETE FROM player_housekeys WHERE houseid = ?', {row.houseid})
 


### PR DESCRIPTION
- I forgot to change the DB query back to RSG's default, which defaulted to '0' instead of NULL. While my DB was set with many foreign keys check, so 'citizenid' column for example, can't be '0' because it's linked to 'citizenid' on the 'players' table (for cascaded UPDATE/DELETE purpose).