### PR TITLE
Fixed houses blips.

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -110,7 +110,6 @@ AddEventHandler('rsg-houses:client:CheckBlip', function()
             SetBlipScale(HouseBlip, 0.1)
             Citizen.InvokeNative(0x9CB1A1623062F402, HouseBlip, Lang:t('client.home_sweet_home'))
             createdEntries[#createdEntries + 1] = {type = "BLIP", handle = HouseBlip}
-            break
         end
 
     end

--- a/client/client.lua
+++ b/client/client.lua
@@ -96,7 +96,15 @@ AddEventHandler('rsg-houses:client:CheckBlip', function()
     for i = 1, #Config.Houses do
         local house = Config.Houses[i]
 
-        if Config.OwnedHouseBlips and house.houseid == myhouse then
+        if not Config.OwnedHouseBlips and house.houseid ~= myhouse then
+            HouseBlip = Citizen.InvokeNative(0x554D9D53F696D002, 1664425300, house.blipcoords)
+            SetBlipSprite(HouseBlip, `blip_robbery_home`, true)
+            SetBlipScale(HouseBlip, 0.1)
+            Citizen.InvokeNative(0x9CB1A1623062F402, HouseBlip, house.name)
+            createdEntries[#createdEntries + 1] = {type = "BLIP", handle = HouseBlip}
+        end
+
+        if house.houseid == myhouse then
             HouseBlip = Citizen.InvokeNative(0x554D9D53F696D002, 1664425300, house.blipcoords)
             SetBlipSprite(HouseBlip, `blip_proc_home`, true)
             SetBlipScale(HouseBlip, 0.1)
@@ -105,19 +113,6 @@ AddEventHandler('rsg-houses:client:CheckBlip', function()
             break
         end
 
-    end
-end)
-
--- show all house blips when Config.OwnedHouseBlips is set to false
-Citizen.CreateThread(function()
-    for _, v in pairs(Config.Houses) do
-        if not Config.OwnedHouseBlips and v.showblip then
-            HouseBlip = Citizen.InvokeNative(0x554D9D53F696D002, 1664425300, v.blipcoords)
-            SetBlipSprite(HouseBlip, `blip_proc_home`, true)
-            SetBlipScale(HouseBlip, 0.1)
-            Citizen.InvokeNative(0x9CB1A1623062F402, HouseBlip, v.name)
-            createdEntries[#createdEntries + 1] = {type = "BLIP", handle = HouseBlip}
-        end
     end
 end)
 

--- a/config.lua
+++ b/config.lua
@@ -17,7 +17,7 @@ Config.PurgeStorage     = false -- purge house inventory when the house is taken
 Config.Blip =
 {
     blipName            = Lang:t('client.estate_agent'), -- Config.Blip.blipName
-    blipSprite          = 'blip_robbery_home', -- Config.Blip.blipSprite
+    blipSprite          = 'blip_ambient_quartermaster', -- Config.Blip.blipSprite
     blipScale           = 0.2 -- Config.Blip.blipScale
 }
 


### PR DESCRIPTION
Fixed to:

- If Config.OwnedHouseBlips is false, it will shows up all blips for houses to sell and player's owned houses.
- If set to true, only will display player's owned houses.